### PR TITLE
Add & setup google tests 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(appnotexd STATIC
   ${SOURCES}
 )
 
-# priduction build
+# Production build
 include_directories(include/AppNotEx/database include/AppNotEx ${ALIB_LIB} ${RANG_LIB} ${SPDLOG_LIB})
 add_executable(appnotex appnotex.cpp ${SOURCES})
 
@@ -55,12 +55,9 @@ add_executable(appnotex appnotex.cpp ${SOURCES})
 enable_testing()
 add_executable(appnotexTest test/appnotexTest.cpp)
 target_link_libraries(appnotexTest appnotexd gtest_main)
-# Add CTests
+# Add CMAKE CTests
 add_test(NAME appnotex_Test COMMAND appnotexTest)
 
+# Build done message
 message("Done Building AppNotEx")
 message("----------------------")
-
-
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,24 +34,27 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 # Build
+            # Sources and Headers of AppNotEx
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE HEADERS "include/AppNotEx/*.hpp")
             # Libraries
 set(ALIB_LIB "lib/ALib/include/alib")
 set(RANG_LIB "lib/ALib/lib/rang")
 set(SPDLOG_LIB "lib/spdlog/include")
+                          # My Own AppNotexLib
+add_library(appnotexd STATIC
+  ${HEADERS}
+  ${SOURCES}
+)
 
 # priduction build
-file(GLOB_RECURSE SOURCES "src/*.cpp")
 include_directories(include/AppNotEx/database include/AppNotEx ${ALIB_LIB} ${RANG_LIB} ${SPDLOG_LIB})
 add_executable(appnotex appnotex.cpp ${SOURCES})
 
-# testing build
+# Testing build
 enable_testing()
-add_library(testlib STATIC
-  include/AppNotEx/database/database.hpp
-  ${SOURCES}
-)
 add_executable(appnotexTest test/appnotexTest.cpp)
-target_link_libraries(appnotexTest testlib gtest_main)
+target_link_libraries(appnotexTest appnotexd gtest_main)
 # Add CTests
 add_test(NAME appnotex_Test COMMAND appnotexTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,15 +21,39 @@ set(CMAKE_CXX_FLAGS "-Wall -v -g -Wextra -Wfatal-errors -lm -lsqlite3")
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 
 
+# Unit Testing using google test
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  # Specify the commit you depend on and update it regularly.
+  URL https://github.com/google/googletest/archive/f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
 # Build
             # Libraries
 set(ALIB_LIB "lib/ALib/include/alib")
 set(RANG_LIB "lib/ALib/lib/rang")
 set(SPDLOG_LIB "lib/spdlog/include")
 
+# priduction build
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 include_directories(include/AppNotEx/database include/AppNotEx ${ALIB_LIB} ${RANG_LIB} ${SPDLOG_LIB})
 add_executable(appnotex appnotex.cpp ${SOURCES})
+
+# testing build
+enable_testing()
+add_library(testlib STATIC
+  include/AppNotEx/database/database.hpp
+  ${SOURCES}
+)
+add_executable(appnotexTest test/appnotexTest.cpp)
+target_link_libraries(appnotexTest testlib gtest_main)
+# Add CTests
+add_test(NAME appnotex_Test COMMAND appnotexTest)
 
 message("Done Building AppNotEx")
 message("----------------------")

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ uninstall:
 	# rm -r ~/.local/bin/AppNotEx -r
 	# rm ~/.local/bin/appnotex
 	# rm ~/.local/bin/data -r
+
+runtest:
+	cd build && cmake .. && make appnotexTest && echo build done test build && echo "" && echo "" && ./../bin/appnotexTest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: run
 
 run:
-	cd build && cmake .. && make && echo build done && echo "" && echo "" && ./../bin/appnotex
+	cd build && cmake .. && make appnotex && echo build done && echo "" && echo "" && ./../bin/appnotex
 
 builddir:
 	mkdir build bin data

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -82,5 +82,12 @@ void Database::printData(COCHAR dbname, COCHAR tbname) {
       "Link', note AS 'Extra Notes' FROM " +
       tablename + ";";
 
-  sqlite3_exec(datadb, selectQuery.c_str(), callback, NULL, NULL);
+  int status = sqlite3_exec(datadb, selectQuery.c_str(), callback, NULL, NULL);
+
+  if (status == SQLITE_OK)
+    logger->info("Print data successfull");
+  else
+    logger->error("Could not read database & fetch data");
+
+  sqlite3_close(datadb);
 }

--- a/test/appnotexTest.cpp
+++ b/test/appnotexTest.cpp
@@ -2,7 +2,7 @@
 
 #include "database.hpp"
 
-TEST(appnotexTest, insertQueryTest) {
+TEST(DatabaseTest, insertQueryTest) {
   // Creating database& Table
   const char *dbfilename = "../data/test/data.db";
   const char *tbname = "DataTest";

--- a/test/appnotexTest.cpp
+++ b/test/appnotexTest.cpp
@@ -4,13 +4,15 @@
 
 TEST(appnotexTest, insertQueryTest) {
   // Creating database& Table
-  const char *dbfilename = "../data/data.db";
-  const char *tbname = "Data";
+  const char *dbfilename = "../data/test/data.db";
+  const char *tbname = "DataTest";
   Database *db = new Database();
 
-  bool status;
-  status =
-      db->insertData(dbfilename, tbname, "Gogle", "Test", "testme", "testme");
+  db->createDb(dbfilename);
+  db->createTable(dbfilename, tbname);
+
+  bool status = db->insertData(dbfilename, tbname, "mutt", "Arch",
+                               "www.mutt.org", "Emailclient-terminal-based");
 
   EXPECT_TRUE(status);
 }

--- a/test/appnotexTest.cpp
+++ b/test/appnotexTest.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+#include "database.hpp"
+
+TEST(appnotexTest, insertQueryTest) {
+  // Creating database& Table
+  const char *dbfilename = "../data/data.db";
+  const char *tbname = "Data";
+  Database *db = new Database();
+
+  bool status;
+  status =
+      db->insertData(dbfilename, tbname, "Gogle", "Test", "testme", "testme");
+
+  EXPECT_TRUE(status);
+}


### PR DESCRIPTION
Why: To test components and maintain good code practices
How: By adding gtest to cmakelists

- Also added a runtest receipe to makefile for easy testrun in terminal
Tags: googletest, tdd, gtest, makefile, cmake, library